### PR TITLE
fix: remove cloud container data deletion

### DIFF
--- a/Chronos/Services/SwiftDataService.swift
+++ b/Chronos/Services/SwiftDataService.swift
@@ -72,7 +72,6 @@ extension SwiftDataService {
 
     func deleteLocallyPersistedChronosData() {
         getLocalModelContainer().deleteAllData()
-        getCloudModelContainer().deleteAllData()
         resetModelContainers()
     }
 }


### PR DESCRIPTION
Deleting the local persistent state of the cloud container may cause unsynced data to be lost. Additionally, removing this data is pointless, as when the container is reinstated, the data will be downloaded from CloudKit again.